### PR TITLE
New mode and endpoint 'color'

### DIFF
--- a/docs/protocol_details.rst
+++ b/docs/protocol_details.rst
@@ -179,6 +179,7 @@ LED operating modes
 Hardware can operate in one of following modes:
 
 * `off` - turns off lights
+* `color` - shows a static color
 * `demo` - starts predefined sequence of effects that are changed after few seconds
 * `movie` - plays predefined or uploaded effect. If movie hasn't been set (yet) code 1104 is returned.
 * `rt` - receive effect in real time

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -54,6 +54,7 @@ Endpoints seem to be organized into hierarchy by applications. Overview of the h
 	* `full`
 
   * `mode`
+  * `color`
   * `effects`
 
     * `current`
@@ -943,6 +944,7 @@ The response will be an object.
 Mode can be one of:
 
 * `off` - lights are turned off
+* `color` - lights show a static color
 * `demo` - demo mode, cycles through pre-defined effects
 * `effect` - plays a predefined effect
 * `movie` - plays an uploaded movie
@@ -1013,6 +1015,137 @@ Request::
 	Content-Length: 15
 
 	{"mode":"demo"}
+
+Response::
+
+	HTTP/1.1 200 Ok
+	Connection: close
+	Content-Length: 13
+	Content-Type: application/json
+
+	{"code":1000}
+
+Get LED color
+-------------
+
+Gets the color shown when in color mode.
+
+Since firmware version 2.7.1 (?)
+
+HTTP request
+````````````
+
+`GET /xled/v1/led/color`
+
+`X-Auth-Token`
+	Authentication token
+
+Response
+````````
+
+The response will be an object.
+
+`hue`
+	(integer), hue component of HSV, in range 0..359
+
+`saturation`
+	(integer), saturation component of HSV, in range 0..255
+
+`value`
+	(integer), value component of HSV, in range 0..255
+
+`red`
+	(integer), red component of RGB, in range 0..255
+
+`green`
+	(integer), green component of RGB, in range 0..255
+
+`blue`
+	(integer), blue component of RGB, in range 0..255
+
+`code`
+	(integer), application return code.
+
+Example
+```````
+Request::
+
+	GET /xled/v1/led/color HTTP/1.1
+	Host: 192.168.4.1
+	Content-Type: application/json
+	X-Auth-Token: 5jPe+ONhwUY=
+
+Response::
+
+	HTTP/1.1 200 Ok
+	Connection: close
+	Content-Length: 84
+	Content-Type: application/json
+
+	{"hue":56,"saturation":105,"value":255,"red":255,"green":248,"blue":150,"code":1000}
+
+Set LED color
+-------------
+
+Sets the color shown when in color mode.
+
+Since firmware version 2.7.1 (?)
+
+HTTP request
+````````````
+
+`POST /xled/v1/led/color`
+
+`X-Auth-Token`
+	Authentication token
+
+Parameters
+``````````
+
+Parameters as JSON object.
+
+Either the three HSV components:
+
+`hue`
+	(integer), hue component of HSV, in range 0..359
+
+`saturation`
+	(integer), saturation component of HSV, in range 0..255
+
+`value`
+	(integer), value component of HSV, in range 0..255
+
+Or the three RGB components:
+
+`red`
+	(integer), red component of RGB, in range 0..255
+
+`green`
+	(integer), green component of RGB, in range 0..255
+
+`blue`
+	(integer), blue component of RGB, in range 0..255
+
+Response
+````````
+
+The response will be an object.
+
+`code`
+	(integer), application return code.
+
+Example
+```````
+
+Request::
+
+	POST /xled/v1/led/color HTTP/1.1
+	Host: 192.168.4.1
+	Content-Type: application/json
+	X-Auth-Token: 5jPe+ONhwUY=
+	Content-Length: 40
+
+	{"hue":300,"saturation":255,"value":255}
 
 Response::
 
@@ -2992,7 +3125,7 @@ The response will be an object.
 `music`
 	(object)
 
-`music`
+`filters`
 	Array of objects
 
 `group`
@@ -3000,6 +3133,9 @@ The response will be an object.
 
 `layout`
 	(object)
+
+`color`
+	(object) corresponds to response of Get LED color without `code`. Since firmware version 2.7.1 (?)
 
 `code`
 	(integer), application return code.

--- a/docs/rest_api.rst
+++ b/docs/rest_api.rst
@@ -1030,7 +1030,7 @@ Get LED color
 
 Gets the color shown when in color mode.
 
-Since firmware version 2.7.1 (?)
+Since firmware version 2.7.1
 
 HTTP request
 ````````````
@@ -1089,7 +1089,7 @@ Set LED color
 
 Sets the color shown when in color mode.
 
-Since firmware version 2.7.1 (?)
+Since firmware version 2.7.1
 
 HTTP request
 ````````````
@@ -3135,7 +3135,7 @@ The response will be an object.
 	(object)
 
 `color`
-	(object) corresponds to response of Get LED color without `code`. Since firmware version 2.7.1 (?)
+	(object) corresponds to response of Get LED color without `code`. Since firmware version 2.7.1
 
 `code`
 	(integer), application return code.


### PR DESCRIPTION
These lights are a moving target - there seems to be a new mode 'color', since at least 2.7.1 but maybe earlier.

These are the related additions in the rest protocol as far as I have been able to figure it out. 

Please, if someone has access to a version 2.5.6, can you check if the endpoint is there already? Try to do GET on /xled/v1/led/color. I have written 2.7.1 in this contribution to the docs for now, for it is where I found it.